### PR TITLE
Update helper utilities with in-browser logging

### DIFF
--- a/examples/google.js
+++ b/examples/google.js
@@ -1,0 +1,26 @@
+const { example } = require("../src/helpers");
+
+example("google.com search", async (page, { action, log }) => {
+  // Go to https://www.google.com/?gws_rd=ssl
+  await page.goto("https://www.google.com/");
+
+  // Click input[aria-label="Search"]
+  await page.click('input[aria-label="Search"]');
+
+  log("Executing search");
+  await page.fill(
+    'input[aria-label="Search"]',
+    "site:wikipedia.org time travel debugging"
+  );
+
+  // Press Enter
+  await Promise.all([
+    page.waitForNavigation(),
+    page.press('input[aria-label="Search"]', "Enter"),
+  ]);
+
+  await action('Showing "About this result"', async () => {
+    await page.click(".g [role='button'] > span");
+    await page.click("#lb [role='button']");
+  });
+});

--- a/examples/yelp.js
+++ b/examples/yelp.js
@@ -1,6 +1,6 @@
-const { example, action } = require("../src/helpers");
+const { example } = require("../src/helpers");
 
-example("Find a thai restaurant on yelp", async (page) => {
+example("Find a thai restaurant on yelp", async (page, { action }) => {
   await action("Search for a thai restaurant", async () => {
     await page.goto("https://www.yelp.com/");
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,30 +5,61 @@ const launchOptions = {
   headless: false,
 };
 
-async function example(name, cbk) {
-  try {
-    const browser = await playwright[browserName].launch(launchOptions);
-    const context = await browser.newContext();
-    const page = await context.newPage();
-
-    console.log(`Starting ${name}`);
-    await cbk(page);
-    console.log(`Finishing ${name}`);
-
-    await page.close();
-    await context.close();
-    await browser.close();
-  } catch (e) {
-    console.error(e);
+let depth = 0;
+const log = (...args) => {
+  if (depth) {
+    console.log("".padStart(depth * 2).substr(1), ...args);
+  } else {
+    console.log(...args);
   }
+};
+
+function wrapped(cbk, pageLog = log) {
+  return async (name, ...args) => {
+    try {
+      await pageLog(`> ${name}`);
+      depth++;
+      return await cbk(...args);
+    } catch (e) {
+      console.error(`Error in ${name}`);
+      console.error(e);
+    } finally {
+      depth--;
+      await pageLog(`< ${name}`);
+    }
+  };
 }
 
-async function action(name, cbk) {
-  console.log(name);
-  await cbk();
-}
+const action = wrapped(async (cbk) => await cbk());
+
+const example = wrapped(async (cbk) => {
+  const browser = await playwright[browserName].launch(launchOptions);
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  log("Browser launched");
+
+  // Create page-bound actions
+  const pageLog = (...args) => {
+    log(...args);
+    return page.evaluate((extArgs) => {
+      console.log("Test Step:", ...extArgs);
+    }, args);
+  };
+  const pageAction = wrapped(async (cbk) => await cbk(), pageLog);
+
+  await action(
+    "Running example",
+    async () => await cbk(page, { log: pageLog, action: pageAction })
+  );
+
+  await page.close();
+  await context.close();
+  await browser.close();
+});
 
 module.exports = {
-  example,
   action,
+  example,
+  log,
 };


### PR DESCRIPTION
Updates `example` helper function to provide `action` and `log` methods to the callback to enable logging test execution steps into the recording.