### PR TITLE
Standardize and clean up examples

### DIFF
--- a/examples/airbnb.js
+++ b/examples/airbnb.js
@@ -2,42 +2,68 @@ const { example } = require("../src/helpers");
 const { nthMatch } = require("../src/selectors");
 const { getBoundingClientRect } = require("../src/dom");
 
-function search(text) {
-  return async (page, { log }) => {
-    const searchFormSelector = "form[action='/s/all']";
-    const inputSelector = `${searchFormSelector} input[data-testid="structured-search-input-field-query"]`;
-    const submitSelector = `${searchFormSelector} [data-testid="structured-search-input-search-button"]`;
-    const dropdownOptionSelector = `${searchFormSelector} [data-testid="structured-search-input-field-query-panel"] li`;
+const selectors = {
+  search: {
+    root: "form[action='/s/all']",
+    get input() {
+      return `${this.root} input[data-testid="structured-search-input-field-query"]`;
+    },
+    get submit() {
+      return `${this.root} [data-testid="structured-search-input-search-button"]`;
+    },
+    get dropdownOption() {
+      return `${this.root} [data-testid="structured-search-input-field-query-panel"] li`;
+    },
+  },
+  results: {
+    filter: {
+      button: "#filter-menu-chip-group button",
+      priceRange: {
+        root: '[data-testid="menuBarPanel-price_range"]',
+        get handle() {
+          return `${this.root} button`;
+        },
+        get save() {
+          return `${this.root} button[data-testid="filter-panel-save-button"]`;
+        },
+      },
+    },
+  },
+};
 
-    await page.click(inputSelector);
-    await page.fill(inputSelector, text);
+function search(text) {
+  return async (page) => {
+    await page.click(selectors.search.input);
+    await page.fill(selectors.search.input, text);
     // TODO: wait for dropdown to populate correctly. not ideal ...
     await page.waitForTimeout(400);
-    await page.click(dropdownOptionSelector);
-    await page.click(submitSelector);
+    await page.click(selectors.search.dropdownOption);
+    await page.click(selectors.search.submit);
   };
 }
 
-const getPriceButton = nthMatch("#filter-menu-chip-group button", 2);
+const getPriceButton = nthMatch(selectors.results.filter.button, 2);
 const getPriceDragHandleBounds = getBoundingClientRect(
-  '[data-testid="menuBarPanel-price_range"] button'
+  selectors.results.filter.priceRange.handle
 );
 
-example("Search Airbnb for Tahoe", async (page, { action, log }) => {
+example("Search Airbnb for Tahoe", async (page, { action, step }) => {
   await page.goto("https://www.airbnb.com/");
 
-  await action("Search for tahoe", search("tahoe"));
+  await step("Search for tahoe", search("tahoe"));
   await action("Filter by Price", async (page, { log }) => {
-    await (await getPriceButton(page)).click();
-    const bounds = await getPriceDragHandleBounds(page);
+    const priceButton = await getPriceButton(page);
+    await priceButton.click();
 
-    const center = bounds.top + bounds.height / 2;
-    log("Click on start and end ranges");
-    await page.mouse.click(bounds.left + 100, center);
-    await page.mouse.click(bounds.left + 300, center);
-    await page.click(
-      '[data-testid="menuBarPanel-price_range"] button[data-testid="filter-panel-save-button"]'
-    );
+    step("Click on start and end ranges", async () => {
+      const bounds = await getPriceDragHandleBounds(page);
+      const center = bounds.top + bounds.height / 2;
+
+      await page.mouse.click(bounds.left + 100, center);
+      await page.mouse.click(bounds.left + 300, center);
+    });
+
+    await page.click(selectors.results.filter.priceRange.save);
 
     await page.waitForTimeout(1000);
   });

--- a/examples/codesandbox.js
+++ b/examples/codesandbox.js
@@ -1,34 +1,46 @@
 const { example } = require("../src/helpers");
 
-const search = (text) => async (page) => {
-  const inputSelector = 'input[placeholder="Search"]';
+const selectors = {
+  files: {
+    root: "section[class *= Files]",
+    get file() {
+      return `${this.root} li`;
+    },
+    fileByName(name) {
+      return `${this.file} >> text=${name}`;
+    },
+  },
+  search: {
+    input: 'input[placeholder="Search"]',
+    button: 'button[aria-label="Search"]',
+    results: 'li[class *= "Result"] button',
+  },
+  tab: ".tab",
+  tabByTitle(title) {
+    return `${this.tab}[title *= "${title}"]`;
+  },
+};
 
+const search = (text) => async (page) => {
   // activate search panel
-  await page.click('button[aria-label="Search"]');
+  await page.click(selectors.search.button);
 
   // activate and fill field
-  await page.click(inputSelector);
-  await page.fill(inputSelector, text);
+  await page.click(selectors.search.input);
+  await page.fill(selectors.search.input, text);
 
   // select first result
-  await page.click('li[class *= "Result"] button');
+  await page.click(selectors.search.results);
 };
 
-const waitForTab = (tab) => async (page) => {
-  return await page.waitForSelector(`.tab[title *= "${tab}"]`);
-};
-
-const waitForIndex = waitForTab("src/index.js");
-const waitForApp = waitForTab("src/App.js");
-
-example("Codesandbox.io", async (page, { action }) => {
+example("Codesandbox.io", async (page, { step }) => {
   await page.goto("https://codesandbox.io/s/0d68e?file=/src/App.js");
 
-  await action("Navigate to index.js", async () => {
-    await page.click('text="index.js"');
-    await waitForIndex(page);
+  await step("Navigate to index.js", async () => {
+    await page.click(selectors.files.fileByName("index.js"));
+    await page.waitForSelector(selectors.tabByTitle("src/index.js"));
   });
 
-  await action("Search for useState", search("useState"));
-  await waitForApp(page);
+  await step("Search for useState", search("useState"));
+  await page.waitForSelector(selectors.tabByTitle("src/App.js"));
 });

--- a/examples/cypress.js
+++ b/examples/cypress.js
@@ -7,15 +7,15 @@ const selectors = {
   sectionToggleButton: "button",
 };
 
-example("Cypress", async (page, { action }) => {
+example("Cypress", async (page, { step }) => {
   await page.goto("https://dashboard.cypress.io/projects/7s5okt/runs");
 
-  await action("View flaky test result", async (page) => {
+  await step("View flaky test result", async (page) => {
     await page.click(selectors.run);
     await page.click(selectors.flakyText);
   });
 
-  await action("Expand runtime environment section", async (page) => {
+  await step("Expand runtime environment section", async (page) => {
     const envSelector = `${selectors.section}:nth-of-type(4) ${selectors.sectionToggleButton}`;
     await page.click(envSelector);
   });

--- a/examples/espn.js
+++ b/examples/espn.js
@@ -1,20 +1,36 @@
 const { example } = require("../src/helpers");
 
+const selectors = {
+  nav: {
+    root: "#global-nav",
+    itemByText(text) {
+      return `${this.root} >> text=${text}`;
+    },
+    team: ".team",
+    teamByText(text) {
+      return `${this.team} >> text=${text}`;
+    },
+  },
+  search: {
+    button: "#global-search-trigger",
+    input: "#global-search input",
+  },
+};
+
 const search = (text) => async (page) => {
-  await page.click("#global-search-trigger");
-  await page.fill("#global-search input", text);
-  await page.press("#global-search input", "Enter");
+  await page.click(selectors.search.button);
+  await page.fill(selectors.search.input, text);
+  await page.press(selectors.search.input, "Enter");
   await page.waitForNavigation();
 };
 
-example("ESPN", async (page, { action }) => {
+example("ESPN", async (page, { step }) => {
   await page.goto("https://www.espn.com/");
 
-  await action("Navigate to Golden State Warriors", async () => {
-    await page.hover('#global-nav >> text="NBA"');
-    await page.waitForTimeout(300);
-    await page.click('.team >> text="Golden State Warriors"');
+  await step("Navigate to Golden State Warriors", async () => {
+    await page.hover(selectors.nav.itemByText("NBA"));
+    await page.click(selectors.nav.teamByText("Golden State Warriors"));
   });
 
-  await action("Search for Steph Curry", search("Steph Curry"));
+  await step("Search for Steph Curry", search("Steph Curry"));
 });

--- a/examples/firebugs.js
+++ b/examples/firebugs.js
@@ -17,13 +17,13 @@ const filter = (type, value) => async (page) => {
   await page.click(selectors.menuItem(value));
 };
 
-example("firebugs.dev", async (page, { action }) => {
+example("firebugs.dev", async (page, { step }) => {
   await page.goto("https://firebugs.dev/");
 
   await page.click(selectors.searchInput);
   await page.fill(selectors.searchInput, "break");
 
-  await action("Filter by bugs", filter("Type", "Bug"));
-  await action("Filter by priority", filter("Priority", "P3"));
-  await action("Filter by keyword", filter("Keyword", "Good First Bugs"));
+  await step("Filter by bugs", filter("Type", "Bug"));
+  await step("Filter by priority", filter("Priority", "P3"));
+  await step("Filter by keyword", filter("Keyword", "Good First Bugs"));
 });

--- a/examples/google.js
+++ b/examples/google.js
@@ -1,26 +1,27 @@
 const { example } = require("../src/helpers");
 
-example("google.com search", async (page, { action, log }) => {
-  // Go to https://www.google.com/?gws_rd=ssl
+const selectors = {
+  search: 'input[aria-label="Search"]',
+  results: {
+    about: ".g [role='button'] > span",
+    closeAbout: "#lb [role='button']",
+  },
+};
+
+example("google.com search", async (page, { step }) => {
   await page.goto("https://www.google.com/");
 
-  // Click input[aria-label="Search"]
-  await page.click('input[aria-label="Search"]');
+  await step("Executing search", async () => {
+    await page.click(selectors.search);
+    await page.fill(
+      selectors.search,
+      "site:wikipedia.org time travel debugging"
+    );
+    await page.press(selectors.search, "Enter");
+  });
 
-  log("Executing search");
-  await page.fill(
-    'input[aria-label="Search"]',
-    "site:wikipedia.org time travel debugging"
-  );
-
-  // Press Enter
-  await Promise.all([
-    page.waitForNavigation(),
-    page.press('input[aria-label="Search"]', "Enter"),
-  ]);
-
-  await action('Showing "About this result"', async () => {
-    await page.click(".g [role='button'] > span");
-    await page.click("#lb [role='button']");
+  await step('Showing "About this result"', async () => {
+    await page.click(selectors.results.about);
+    await page.click(selectors.results.closeAbout);
   });
 });

--- a/examples/notion.js
+++ b/examples/notion.js
@@ -12,12 +12,12 @@ const selectors = {
   },
 };
 
-example("Notion - Replay Docs", async (page, { action }) => {
+example("Notion - Replay Docs", async (page, { step }) => {
   await page.goto(
     "https://www.notion.so/replayio/Replay-Docs-56758667f53a4d51b7c6fc7a641adb02"
   );
 
-  await action("Search for 'help'", async () => {
+  await step("Search for 'help'", async () => {
     await page.click(selectors.search);
     await page.click(selectors.searchField);
 

--- a/examples/nytimes.js
+++ b/examples/nytimes.js
@@ -14,7 +14,7 @@ const selectors = {
   },
 };
 
-example("nytimes.com", async (page, { action }) => {
+example("nytimes.com", async (page, { step }) => {
   // using a lighter-weight starting page than the root
   await page.goto("https://www.nytimes.com/sitemap");
 
@@ -26,7 +26,7 @@ example("nytimes.com", async (page, { action }) => {
 
   await Promise.all([
     page.waitForNavigation(),
-    action("Search for 'climate'", async () => {
+    step("Search for 'climate'", async () => {
       await page.click(selectors.searchButton);
       await page.fill(selectors.searchInput, "climate");
       await page.press(selectors.searchInput, "Enter");

--- a/examples/reactvirtualized.js
+++ b/examples/reactvirtualized.js
@@ -17,17 +17,17 @@ const scrollThroughList = async (page) => {
   }
 };
 
-example("react-virtualized", async (page, { action }) => {
+example("react-virtualized", async (page, { step }) => {
   await page.goto(
     "https://bvaughn.github.io/react-virtualized/#/components/List"
   );
 
-  await action("Scroll through list", scrollThroughList);
+  await step("Scroll through list", scrollThroughList);
 
-  await action("Toggle options", async () => {
+  await step("Toggle options", async () => {
     await page.click(selectors.dynamicHeightLabel);
     await page.click(selectors.scrollPlaceholderLabel);
   });
 
-  await action("Scroll through list", scrollThroughList);
+  await step("Scroll through list", scrollThroughList);
 });

--- a/examples/realadvisor.js
+++ b/examples/realadvisor.js
@@ -1,4 +1,4 @@
-const { example, action } = require("../src/helpers");
+const { example } = require("../src/helpers");
 
 const selectors = {
   addressSearch: {
@@ -31,7 +31,7 @@ const selectors = {
   },
 };
 
-example("RealAdvisor", async (page) => {
+example("RealAdvisor", async (page, { step }) => {
   await page.goto("https://realadvisor.ch/");
 
   await Promise.all([
@@ -39,12 +39,12 @@ example("RealAdvisor", async (page) => {
     page.click(selectors.addressSearch.buy),
   ]);
 
-  await action("Search for listings", async () => {
+  await step("Search for listings", async () => {
     await page.click(selectors.addressSearch.input);
     await page.click(selectors.addressSearch.submit);
   });
 
-  await action("Sort by Most Recent", async () => {
+  await step("Sort by Most Recent", async () => {
     await page.click(selectors.results.sort);
     await page.click(selectors.filter.optionByText("Most recent"));
     await page.waitForSelector("[class*=useGridLoadingStyle]", {
@@ -52,7 +52,7 @@ example("RealAdvisor", async (page) => {
     });
   });
 
-  await action("Open first listing", async () => {
+  await step("Open first listing", async () => {
     // TODO: Bit of flakiness bevause the listing entry still exists while
     // loading so giving a little time for it to be replaced with the valid
     // entry post filter

--- a/examples/reddit.js
+++ b/examples/reddit.js
@@ -6,11 +6,11 @@ const selectors = {
   community: '*css=a >> button:text("Join")',
 };
 
-example("Reddit", async (page, { action }) => {
+example("Reddit", async (page, { step }) => {
   // Lower-weight starting page to avoid load timeouts
   await page.goto("https://www.reddit.com/topics/a-1/");
 
-  await action("Search for climate", async () => {
+  await step("Search for climate", async () => {
     await page.fill(selectors.search, "climate");
     await page.press(selectors.search, "Enter");
   });

--- a/examples/replit.js
+++ b/examples/replit.js
@@ -42,17 +42,17 @@ const login = (
   await page.click(selectors.loginButton);
 };
 
-example("repl.it", async (page, { action }) => {
+example("repl.it", async (page, { step }) => {
   await page.goto("https://replit.com/site/pricing");
 
-  await action("Login", login());
-  await action("Navigate to sample repl", async () => {
+  await step("Login", login());
+  await step("Navigate to sample repl", async () => {
     await page.click(selectors.myRepls);
     await page.click(`${selectors.item} >> text="Playwright Sample"`);
   });
 
-  await clearCode(page);
-  await action(
+  await step("Clearing code", clearCode);
+  await step(
     "Appending code",
     appendCode(`
 for (let i = 0; i < 10; i++) {

--- a/examples/shared/storybook.js
+++ b/examples/shared/storybook.js
@@ -22,15 +22,13 @@ const selectors = {
 
 // Navigates to either a story or a folder (if the path includes a trailing slash).
 // A leading slash is optional.
-const openStory = async (action, path, callback) => {
-  await action(`Open story: ${path}`, async (page, ...rest) => {
-    await page.click(selectors.storyByPath(path));
-    await page.waitForTimeout(500);
+const openStory = (path, callback) => async (page, ...rest) => {
+  await page.click(selectors.storyByPath(path));
+  await page.waitForTimeout(500);
 
-    if (callback) {
-      await callback(page, ...rest);
-    }
-  });
+  if (callback) {
+    await callback(page, ...rest);
+  }
 };
 
 module.exports = {

--- a/examples/storybook-ui.js
+++ b/examples/storybook-ui.js
@@ -1,15 +1,20 @@
 const { example } = require("../src/helpers");
 const { selectors, openStory } = require("./shared/storybook");
 
-example("Storyboook UI", async (page, { action }) => {
+example("Storyboook UI", async (page, { action, step }) => {
   await page.goto("https://5ccbc373887ca40020446347-qbeeoghter.chromatic.com/");
 
-  await openStory(action, "/Avatar/");
-  await openStory(action, "/Avatar/Large");
-  await openStory(action, "/Avatar/Small");
-  await openStory(action, "/CodeSnippets/");
-  await openStory(action, "/CodeSnippets/Multiple");
-
-  await page.click(selectors.tabByTitle("Actions"));
-  await page.click(selectors.tabByTitle("Story"));
+  await step("/Avatar/", openStory("/Avatar/"));
+  await step("/Avatar/Large", openStory("/Avatar/Large"));
+  await step("/Avatar/Small", openStory("/Avatar/Small"));
+  await step("/CodeSnippets/", openStory("/CodeSnippets/"));
+  await action(
+    "/CodeSnippets/Multiple",
+    openStory("/CodeSnippets/Multiple", () =>
+      step("Select tabs", async () => {
+        await page.click(selectors.tabByTitle("Actions"));
+        await page.click(selectors.tabByTitle("Story"));
+      })
+    )
+  );
 });

--- a/examples/storybook.js
+++ b/examples/storybook.js
@@ -1,39 +1,49 @@
 const { example } = require("../src/helpers");
 const { openStory, selectors } = require("./shared/storybook");
 
-example("Storybook", async (page, { action }) => {
+example("Storybook", async (page, { action, step }) => {
   await page.goto("https://next--storybookjs.netlify.app/official-storybook/");
 
-  await openStory(action, "/Addons/A11y/BaseButton/Label");
-  await openStory(action, "/Addons/A11y/BaseButton/Disabled");
-  await openStory(action, "/Addons/Backgrounds/");
-  await openStory(action, "/Addons/Backgrounds/Overridden", async () => {
-    await action("Zoom story", async () => {
-      for (let i = 0; i < 5; i++) {
-        await page.click(selectors.toolbarButtonByTitle("Zoom in"));
-      }
-      for (let i = 0; i < 5; i++) {
-        await page.click(selectors.toolbarButtonByTitle("Zoom out"));
-      }
-    });
+  await step(
+    "/Addons/A11y/BaseButton/Label",
+    openStory("/Addons/A11y/BaseButton/Label")
+  );
+  await step(
+    "/Addons/A11y/BaseButton/Disabled",
+    openStory("/Addons/A11y/BaseButton/Disabled")
+  );
+  await step("/Addons/Backgrounds/", openStory("/Addons/Backgrounds/"));
+  await action(
+    "/Addons/Backgrounds/Overridden",
+    openStory("/Addons/Backgrounds/Overridden", async (page, { step }) => {
+      await step("Zoom story", async () => {
+        for (let i = 0; i < 5; i++) {
+          await page.click(selectors.toolbarButtonByTitle("Zoom in"));
+        }
+        for (let i = 0; i < 5; i++) {
+          await page.click(selectors.toolbarButtonByTitle("Zoom out"));
+        }
+      });
 
-    await action("Activate tabs", async (page, { log }) => {
-      const tabs = [
-        "Controls",
-        "Actions",
-        "Story",
-        "Events",
-        "Knobs",
-        "CSS",
-        "Accessibility",
-        "Tests",
-      ];
+      await action("Activate tabs", async (page, { step }) => {
+        const tabs = [
+          "Controls",
+          "Actions",
+          "Story",
+          "Events",
+          "Knobs",
+          "CSS",
+          "Accessibility",
+          "Tests",
+        ];
 
-      for (let i = 0; i < tabs.length; i++) {
-        log("Selecting", tabs[i]);
-        await page.click(selectors.tabByTitle(tabs[i]));
-        await page.waitForTimeout(250);
-      }
-    });
-  });
+        for (let tab of tabs) {
+          await step(`Selecting ${tab}`, async () => {
+            await page.click(selectors.tabByTitle(tab));
+            await page.waitForTimeout(250);
+          });
+        }
+      });
+    })
+  );
 });

--- a/examples/tablecheck.js
+++ b/examples/tablecheck.js
@@ -34,10 +34,10 @@ const selectors = {
 
 const getSliderBounds = getBoundingClientRect(selectors.results.filter.slider);
 
-example("TableCheck", async (page, { action }) => {
+example("TableCheck", async (page, { action, step }) => {
   await page.goto("https://www.tablecheck.com/en/japan");
 
-  await action("Search for Tokyo", async (page, { log }) => {
+  await step("Search for Tokyo", async (page) => {
     await page.click(selectors.search.input);
     await page.type(selectors.search.input, "tokyo");
     await page.click(selectors.search.optionByText("Tokyo"));
@@ -46,23 +46,24 @@ example("TableCheck", async (page, { action }) => {
 
   await page.waitForSelector(selectors.results.item);
 
-  await action("Filter by budget", async (page, { log }) => {
+  await action("Filter by budget", async (page, { step }) => {
     await page.click(selectors.results.filter.open);
     await page.waitForTimeout(1000); // animation timeout
 
-    const bounds = await getSliderBounds(page);
-    const center = bounds.top + bounds.height / 2;
+    step("Set min and max budget", async () => {
+      const bounds = await getSliderBounds(page);
+      const center = bounds.top + bounds.height / 2;
 
-    log("Set min and max budget");
-    await page.mouse.click(
-      bounds.left + Math.round(bounds.width * 0.25),
-      center
-    );
+      await page.mouse.click(
+        bounds.left + Math.round(bounds.width * 0.25),
+        center
+      );
 
-    await page.mouse.click(
-      bounds.left + Math.round(bounds.width * 0.75),
-      center
-    );
+      await page.mouse.click(
+        bounds.left + Math.round(bounds.width * 0.75),
+        center
+      );
+    });
 
     await Promise.all([
       page.waitForSelector(selectors.results.filter.dialog, {

--- a/examples/unsplash.js
+++ b/examples/unsplash.js
@@ -16,23 +16,23 @@ const selectors = {
   },
 };
 
-example("Unsplash", async (page, { action }) => {
+example("Unsplash", async (page, { step }) => {
   await page.goto("https://unsplash.com/");
 
-  await action("Search for trees", async () => {
+  await step("Search for trees", async () => {
     await page.click(selectors.search.input);
     await page.fill(selectors.search.input, "trees");
     await page.press(selectors.search.input, "Enter");
   });
 
-  await action("Navigate through results", async () => {
+  await step("Navigate through results", async () => {
     await page.click(selectors.search.results.image);
     await page.click(selectors.search.results.next);
     await page.click(selectors.search.results.next);
     await page.click(selectors.search.results.next);
   });
 
-  await action("Select tag", async () => {
+  await step("Select tag", async () => {
     await page.click(selectors.search.results.tag);
     await page.waitForLoadState("networkidle");
     await page.click(selectors.search.results.image);

--- a/examples/vscode.js
+++ b/examples/vscode.js
@@ -73,8 +73,8 @@ const selectFile = async (path, page, doubleClick = false) => {
   await page.waitForTimeout(250);
 };
 
-example("Visual Studio Code", async (page, { action }) => {
-  await action("Open Editor", async () => {
+example("Visual Studio Code", async (page, { action, step }) => {
+  await step("Open Editor", async () => {
     await page.goto("https://vscode-web-test-playground.azurewebsites.net/");
 
     await page.click('text="Click to Continue"');
@@ -86,14 +86,14 @@ example("Visual Studio Code", async (page, { action }) => {
     ]);
   });
 
-  await action("Open files", async () => {
+  await step("Open files", async () => {
     await selectFile("~/sample-folder/file.css", page);
     await selectFile("~/sample-folder/file.html", page);
     await selectFile("~/sample-folder/file.js", page, true);
     await selectFile("~/sample-folder/file.md", page, true);
   });
 
-  await action("Search files", async () => {
+  await step("Search files", async () => {
     await page.click(selectors.activityBar.itemByTitle("Search"));
     await page.click(selectors.search.input);
     await page.fill(selectors.search.input, "store");
@@ -110,7 +110,7 @@ example("Visual Studio Code", async (page, { action }) => {
     await page.click(selectors.activityBar.menu.itemByLabel("File"));
     await page.click(selectors.activityBar.menu.itemByLabel("New File"));
 
-    await action("Add content and save", async () => {
+    await step("Add content and save", async () => {
       await page.waitForSelector(selectors.editor.tabByTitle("Untitled"));
       await page.type(monacoSelectors.input, "Testing");
       await page.press(monacoSelectors.input, "Meta+s");

--- a/examples/yelp.js
+++ b/examples/yelp.js
@@ -1,34 +1,41 @@
 const { example } = require("../src/helpers");
+const { nthMatch } = require("../src/selectors");
+const { asyncClick } = require("../src/dom");
+
+const selectors = {
+  search: {
+    root: "form[action='/search']",
+    get input() {
+      return `${this.root} input:not([tabIndex = "-1"])`;
+    },
+    get submit() {
+      return `${this.root} button[type='submit']`;
+    },
+  },
+  results: 'li h4 a[href *= "/biz/"]',
+};
 
 // Searches for results on the main page or via header on detail page
 function search(text) {
   return async (page) => {
-    const searchFormSelector = "form[action='/search']";
-    const inputSelector = `${searchFormSelector} input:not([tabIndex = "-1"])`;
-    const submitSelector = `${searchFormSelector} button[type='submit']`;
-
-    await page.click(inputSelector);
-    await page.fill(inputSelector, text);
-    await page.click(submitSelector);
+    await page.click(selectors.search.input);
+    await page.fill(selectors.search.input, text);
+    await page.click(selectors.search.submit);
   };
 }
 
-// returns the nth (0-based) non-sponsored result
-function selectNthResult(n = 0) {
-  return async (page) => {
-    const elements = await page.$$('li h4 a[href *= "/biz/"]');
-    if (elements[n]) {
-      await elements[n].click();
-    }
-  };
-}
-
-example("Find a thai restaurant on yelp", async (page, { action }) => {
+example("Find a thai restaurant on yelp", async (page, { step }) => {
   await page.goto("https://www.yelp.com/");
 
-  await action("Search for a thai restaurant", search("thai"));
-  await action("Click on the first result", selectNthResult());
+  await step("Search for a thai restaurant", search("thai"));
+  await step(
+    "Click on the first result",
+    asyncClick(nthMatch(selectors.results, 0))
+  );
 
-  await action("Search for a taco restaurant", search("taco"));
-  await action("Click on the first result", selectNthResult());
+  await step("Search for a taco restaurant", search("taco"));
+  await step(
+    "Click on the second result",
+    asyncClick(nthMatch(selectors.results, 1))
+  );
 });

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,3 +1,6 @@
+// Utility method that clicks the return value of an async function (e.g. nthMatch)
+const asyncClick = (cbk) => (...args) => cbk(...args).then((m) => m.click());
+
 function getBoundingClientRect(selector) {
   return async (page) => {
     const el = await page.waitForSelector(selector);
@@ -28,6 +31,7 @@ function waitForFrameNavigated(url) {
 }
 
 module.exports = {
+  asyncClick,
   getBoundingClientRect,
   waitForTitleChange,
   waitForFrameNavigated,


### PR DESCRIPTION
* Move selectors to the top of each file
* Use `step` instead of `action` when there aren't any other logs for better reporting output
* Change `openStory` in shared storybook utility to work better with `action`/`step`