### PR TITLE
Add webgl samples from MDN

### DIFF
--- a/examples/mdn.webgl.js
+++ b/examples/mdn.webgl.js
@@ -1,0 +1,38 @@
+const { example } = require("../src/helpers");
+const { waitForFrameNavigated } = require("../src/dom");
+
+const waitForSample = waitForFrameNavigated(/mozit.cloud/);
+
+example("MDN WebGL Samples", async (page, { action, step }) => {
+  await step("Basic scissoring", () =>
+    page.goto(
+      "https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example/Basic_scissoring"
+    )
+  );
+
+  await step("Clearing by clicking", async (page, { log }) => {
+    const [frame] = await Promise.all([
+      waitForSample(page),
+      page.goto(
+        "https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example/Clearing_by_clicking"
+      ),
+    ]);
+
+    await page.waitForLoadState("networkidle");
+
+    await frame.click("#color-switcher");
+    await frame.click("#color-switcher");
+    await frame.click("#color-switcher");
+  });
+
+  await step("Scissor animation", () =>
+    page.goto(
+      "https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example/Scissor_animation"
+    )
+  );
+  await step("Textures from code", () =>
+    page.goto(
+      "https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/By_example/Textures_from_code"
+    )
+  );
+});


### PR DESCRIPTION
Cherry picked a couple webgl samples from MDN.

> These currently fail in playwright for replay but appear to work in the latest release builds.

Relates to #71 