### PR TITLE
Update playwright

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM mcr.microsoft.com/playwright@sha256:45243b7a97477423de2807804f2b623159eea2dd0e0055c28dafd23c65a2e508
 
 # Replace firefox installation
-RUN cd /root/.cache/ms-playwright/firefox-1225 && rm -rf firefox && curl https://replay.io/downloads/linux-replay-playwright.tar.xz > firefox.tar.xz && tar xf firefox.tar.xz && rm firefox.tar.xz && cd /
+RUN cd /root/.cache/ms-playwright/firefox-1238 && rm -rf firefox && curl https://replay.io/downloads/linux-replay-playwright.tar.xz > firefox.tar.xz && tar xf firefox.tar.xz && rm firefox.tar.xz && cd /
 
 # Download record/replay driver
 RUN curl https://replay.io/downloads/linux-recordreplay.so > /root/.cache/ms-playwright/linux-recordreplay.so

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The `examples` directory contains playwright scripts that perform a fixed series
 
 1. `npm ci` Install dependencies
 2. `./install_macOS.sh` Install Replay
-3. `PLAYWRIGHT_BROWSERS_PATH=$PWD/browsers RECORD_REPLAY_DRIVER=$PWD/browsers/firefox-1225/macOS-recordreplay.so RECORD_REPLAY_RECORDING_ID_FILE=$PWD/recordings.log RECORD_REPLAY_SERVER=wss://dispatch.replay.io RECORD_ALL_CONTENT=1 node examples/whatsmyuseragent.js` run test
+3. `PLAYWRIGHT_BROWSERS_PATH=$PWD/browsers RECORD_REPLAY_DRIVER=$PWD/browsers/firefox-1238/macOS-recordreplay.so RECORD_REPLAY_RECORDING_ID_FILE=$PWD/recordings.log RECORD_REPLAY_SERVER=wss://dispatch.replay.io RECORD_ALL_CONTENT=1 node examples/whatsmyuseragent.js` run test
 4. `cat recordings.log` to view the last recording
 
 ### Docker installation
@@ -29,7 +29,7 @@ The image can also be built directly with `docker build --no-cache -t recordrepl
 
 ### Playwright version
 
-All runs using scripts in this repository are currently version locked to playwright 1.8.1, due to the changing names for firefox subdirectories (e.g. firefox-1225) between playwright versions. This would be nice to improve.
+All runs using scripts in this repository are currently version locked to playwright 1.10.0, due to the changing names for firefox subdirectories (e.g. firefox-1238) between playwright versions. This would be nice to improve.
 
 ### Running the playwright examples
 

--- a/install_macOS.sh
+++ b/install_macOS.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 mkdir browsers
-mkdir browsers/firefox-1225
-cd browsers/firefox-1225
+mkdir browsers/firefox-1238
+cd browsers/firefox-1238
 wget https://replay.io/downloads/macOS-replay-playwright.tar.xz
 wget https://replay.io/downloads/macOS-recordreplay.so
 tar xf macOS-replay-playwright.tar.xz

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,6 +77,11 @@
         "once": "^1.4.0"
       }
     },
+    "escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -192,9 +197,9 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "playwright": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.8.1.tgz",
-      "integrity": "sha512-nmuiDEDwB/SdAxiZQS5pLqPS3XXN8OJ1LKvTSiAbJvu+AUf7f0RD7nuq9xB0C08Emd6stx9yBMhANvD12k/+GQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.10.0.tgz",
+      "integrity": "sha512-b7SGBcCPq4W3pb4ImEDmNXtO0ZkJbZMuWiShsaNJd+rGfY/6fqwgllsAojmxGSgFmijYw7WxCoPiAIEDIH16Kw==",
       "requires": {
         "commander": "^6.1.0",
         "debug": "^4.1.1",
@@ -207,6 +212,7 @@
         "proper-lockfile": "^4.1.1",
         "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
+        "stack-utils": "^2.0.3",
         "ws": "^7.3.1"
       }
     },
@@ -261,6 +267,14 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+    },
+    "stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/RecordReplay/playwright-tests#readme",
   "dependencies": {
     "dotenv": "^8.2.0",
-    "playwright": "1.8.1"
+    "playwright": "1.10.0"
   }
 }

--- a/run.ts
+++ b/run.ts
@@ -20,7 +20,8 @@ let gNeedUpdate = false;
 let gRecordingFile: string | undefined;
 
 // Container runs aren't supported with chromium yet.
-let gUseContainer = process.platform == "linux" && !process.env.PLAYWRIGHT_CHROMIUM;
+let gUseContainer =
+  process.platform == "linux" && !process.env.PLAYWRIGHT_CHROMIUM;
 
 const gChromium = !!process.env.PLAYWRIGHT_CHROMIUM;
 
@@ -58,10 +59,12 @@ if (gTests.length && !gRecordingFile) {
   process.exit(1);
 }
 
-const BrowserDir = process.env.REPLAY_PLAYWRIGHT_BROWSER || `${process.env.HOME}/.replay-playwright-browser`;
+const BrowserDir =
+  process.env.REPLAY_PLAYWRIGHT_BROWSER ||
+  `${process.env.HOME}/.replay-playwright-browser`;
 
 // These will need updating when we move to a more recent version of playwright.
-const BrowserSubdirGecko = `${BrowserDir}/firefox-1225`;
+const BrowserSubdirGecko = `${BrowserDir}/firefox-1238`;
 const BrowserSubdirChromium = `${BrowserDir}/chromium-844399`;
 
 const BrowserSubdir = gChromium ? BrowserSubdirChromium : BrowserSubdirGecko;
@@ -75,13 +78,21 @@ function mkdirSyncIfNotExists(dir: string) {
 function updateBrowser() {
   if (gUseContainer) {
     if (!gNeedUpdate) {
-      const { stdout } = spawnChecked("docker", ["image", "ls", "recordreplayinc/playwright:latest"]);
+      const { stdout } = spawnChecked("docker", [
+        "image",
+        "ls",
+        "recordreplayinc/playwright:latest",
+      ]);
       if (stdout.includes("recordreplayinc/playwright")) {
         return;
       }
     }
 
-    spawnChecked("docker", ["image", "pull", "recordreplayinc/playwright:latest"], { stdio: "inherit" });
+    spawnChecked(
+      "docker",
+      ["image", "pull", "recordreplayinc/playwright:latest"],
+      { stdio: "inherit" }
+    );
     return;
   }
 
@@ -100,8 +111,8 @@ function updateBrowser() {
   }
 
   const archive = gChromium
-   ? `${currentPlatform()}-replay-chromium.tar.xz`
-   : `${currentPlatform()}-replay-playwright.tar.xz`;
+    ? `${currentPlatform()}-replay-chromium.tar.xz`
+    : `${currentPlatform()}-replay-playwright.tar.xz`;
 
   spawnChecked("rm", ["-rf", BrowserSubdir]);
 
@@ -111,14 +122,21 @@ function updateBrowser() {
     cwd: BrowserSubdir,
     stdio: "inherit",
   });
-  spawnChecked("wget", [`https://replay.io/downloads/${currentPlatform()}-recordreplay.so`], {
-    cwd: BrowserSubdir,
-    stdio: "inherit",
-  });
+  spawnChecked(
+    "wget",
+    [`https://replay.io/downloads/${currentPlatform()}-recordreplay.so`],
+    {
+      cwd: BrowserSubdir,
+      stdio: "inherit",
+    }
+  );
   spawnChecked("tar", ["xf", archive], { cwd: BrowserSubdir });
 
   if (gChromium) {
-    spawnChecked("mv", ["replay-chromium", subdirContents], { cwd: BrowserSubdir, stdio: "inherit" });
+    spawnChecked("mv", ["replay-chromium", subdirContents], {
+      cwd: BrowserSubdir,
+      stdio: "inherit",
+    });
   }
 }
 
@@ -146,18 +164,27 @@ ts-node playwright-tests/${test}
       envArgs.push("-e", `${key}=${value}`);
     }
 
-    spawnChecked("docker", [
-      "run",
-      "-v", `${__dirname}:/playwright-tests`,
-      "-e", `RECORD_REPLAY_RECORDING_ID_FILE=/playwright-tests/${tmpRecordingFile}`,
-      "-e", `RECORD_REPLAY_SERVER=${server}`,
-      "-e", "RECORD_ALL_CONTENT=1",
-      "-e", "PLAYWRIGHT_HEADLESS=1",
-      ...envArgs,
-      "recordreplayinc/playwright:latest",
-      "bash",
-      `/playwright-tests/${tmpScriptFile}`,
-    ], { stdio: "inherit" });
+    spawnChecked(
+      "docker",
+      [
+        "run",
+        "-v",
+        `${__dirname}:/playwright-tests`,
+        "-e",
+        `RECORD_REPLAY_RECORDING_ID_FILE=/playwright-tests/${tmpRecordingFile}`,
+        "-e",
+        `RECORD_REPLAY_SERVER=${server}`,
+        "-e",
+        "RECORD_ALL_CONTENT=1",
+        "-e",
+        "PLAYWRIGHT_HEADLESS=1",
+        ...envArgs,
+        "recordreplayinc/playwright:latest",
+        "bash",
+        `/playwright-tests/${tmpScriptFile}`,
+      ],
+      { stdio: "inherit" }
+    );
 
     if (fs.existsSync(tmpRecordingPath)) {
       fs.copyFileSync(tmpRecordingPath, gRecordingFile || "");


### PR DESCRIPTION
This is still failing with this error code even though we should have a firefox with the right version there

```
(node:71888) UnhandledPromiseRejectionWarning: browserType.launch: Failed to launch firefox because executable doesn't exist at /Users/jasonlaster/src/replay/playwright-tests/browsers/firefox-1238/firefox/Nightly.app/Contents/MacOS/firefox
Try re-installing playwright with "npm install playwright"
Error
    at Object.captureStackTrace (/Users/jasonlaster/src/replay/playwright-tests/node_modules/playwright/lib/utils/stackTrace.js:48:19)
    at Connection.sendMessageToServer (/Users/jasonlaster/src/replay/playwright-tests/node_modules/playwright/lib/client/connection.js:69:48)
    at Proxy.<anonymous> (/Users/jasonlaster/src/replay/playwright-tests/node_modules/playwright/lib/client/channelOwner.js:64:61)
    at /Users/jasonlaster/src/replay/playwright-tests/node_modules/playwright/lib/client/browserType.js:64:67
    at BrowserType._wrapApiCall (/Users/jasonlaster/src/replay/playwright-tests/node_modules/playwright/lib/client/channelOwner.js:77:34)
    at BrowserType.launch (/Users/jasonlaster/src/replay/playwright-tests/node_modules/playwright/lib/client/browserType.js:55:21)
    at /Users/jasonlaster/src/replay/playwright-tests/src/helpers.js:74:49
    at /Users/jasonlaster/src/replay/playwright-tests/src/helpers.js:31:20
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:71888) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:71888) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```