### PR TITLE
Fix recording failure when metadata file does not exist

### DIFF
--- a/src/metadata.js
+++ b/src/metadata.js
@@ -76,18 +76,18 @@ async function uploadMetadata(gRecordingFile, gMetadataFile) {
   );
 
   const recordingId = lastLine(gRecordingFile);
-  const metadata = JSON.parse(lastLine(gMetadataFile));
-
-  const variables = {
-    recording_id: recordingId,
-    id: recordingId,
-    workspace_id: process.env.WORKSPACE_ID,
-    user_id: process.env.USER_ID,
-    last_screen_mime_type: "image/jpeg",
-    ...metadata,
-  };
-
   try {
+    const metadata = JSON.parse(lastLine(gMetadataFile));
+
+    const variables = {
+      recording_id: recordingId,
+      id: recordingId,
+      workspace_id: process.env.WORKSPACE_ID,
+      user_id: process.env.USER_ID,
+      last_screen_mime_type: "image/jpeg",
+      ...metadata,
+    };
+
     await upload(`UpdateTest`, UPDATE_TEST, variables);
   } catch (e) {
     console.error("Failed to upload metadata", e);


### PR DESCRIPTION
## Issue

Our QA Wolf tests do not (currently) create a metadata file so this function throws when trying to read the non-existent file and causes the test to "fail" (exit with non-zero) even though the test itself ran correctly.

## Resolution

Move the `try` up a bit so it catches this failure and logs the metadata access error but doesn't fail the test