### PR TITLE
Add ignore list to test manifest

### DIFF
--- a/test-manifest.js
+++ b/test-manifest.js
@@ -2,9 +2,11 @@ const fs = require("fs");
 const path = require("path");
 const env = require("dotenv").config();
 
+const ignoreList = ["helpers.js"];
+
 const qawolf = fs
   .readdirSync(path.join(__dirname, "qawolf"))
-  .filter((name) => name.endsWith(".js"))
+  .filter((name) => name.endsWith(".js") && !ignoreList.includes(name))
   .map((name) => ({
     name: `qawolf/${name}`,
     env,


### PR DESCRIPTION
We were trying to run `helpers.js` as a test so let's ignore it and make space for other QA wolf tests we might want to ignore/skip.