### PR TITLE
Extend QA Wolf test timeout to 60s

### DIFF
--- a/.github/workflows/qawolf/sync.js
+++ b/.github/workflows/qawolf/sync.js
@@ -35,6 +35,7 @@ function formatHelpers(code) {
   
     const browser = await playwright[browserName].launch({
       headless,
+      timeout: 60000,
     });
     const context = await browser.newContext();
     return { browser, context };


### PR DESCRIPTION
We're seeing some timeouts in our test runner that seem to coincide with the current 30s timeout. Extending it to 60s to see if that resolves things.